### PR TITLE
Added that skip button is hidden on certain screens

### DIFF
--- a/screens/ReportScreen.tsx
+++ b/screens/ReportScreen.tsx
@@ -50,6 +50,23 @@ const ReportScreen = ({ navigation }: RootTabScreenProps<'TabReport'>) => {
     };
   }
 
+  function hideSkip() {
+    if (
+      currentStep === 0.3 ||
+      currentStep === 0.4 ||
+      currentStep === 0.5 ||
+      currentStep === 0.7 ||
+      currentStep === 0.8
+    ) {
+      return {
+        display: 'initial',
+      };
+    }
+    return {
+      display: 'none',
+    };
+  }
+
   function closeReport() {
     navigation.navigate('Root', { screen: 'TabHome' });
   }
@@ -150,7 +167,11 @@ const ReportScreen = ({ navigation }: RootTabScreenProps<'TabReport'>) => {
         {renderStepDisplay(currentStep)}
         <View style={[sharedStyles.report_screen_buttons, getVisibility()]}>
           <ButtonIncident title="Volgende" method={handleStepNext} />
-          <ButtonIncident title="Overslaan" style={{ marginTop: 10 }} method={handleStepNext} />
+          <ButtonIncident
+            style={[sharedStyles.report_screen_button_skip, hideSkip()]}
+            title="Overslaan"
+            method={handleStepNext}
+          />
         </View>
       </View>
     </>

--- a/screens/shared.scss
+++ b/screens/shared.scss
@@ -19,6 +19,10 @@
   flex-direction: column;
 }
 
+.report_screen_button_skip {
+  margin-top: 10px;
+}
+
 .textButton {
   font-weight: 600;
 }


### PR DESCRIPTION
The skip button is no longer shown on certain screens in the report flow.

On the following screens, the skip button is now hidden.

- Add picture
- Additional information
- Name person involved
- Assistance witness / Witness